### PR TITLE
Install `yargs` for parsing arguments instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",
     "node-fetch": "^2.6.1",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "yargs": "^17.2.0"
   },
   "bin": {
     "create-three-app": "./src/index.js"


### PR DESCRIPTION
When it comes to CLI arg-parsing, almost no other library can beat [yargs](npmjs.com/package/yargs), and if this is to be considered a serious project you should add more options and configuration. This of course requires parsing, and yargs can do it all.
- cursorsdottsx's alt